### PR TITLE
Fix code exchange ensure the authz code was issued to the requesting client

### DIFF
--- a/src/pyop/client_authentication.py
+++ b/src/pyop/client_authentication.py
@@ -61,4 +61,4 @@ def verify_client_authentication(clients, parsed_request, authz_header=None):
         raise InvalidClientAuthentication(
             'Wrong authentication method used, MUST use \'{}\''.format(expected_authn_method))
 
-    return True
+    return client_id

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -410,8 +410,7 @@ class Provider(object):
         if http_headers is None:
             http_headers = {}
         token_request = dict(parse_qsl(request_body))
-        client_id = verify_client_authentication(self.clients, token_request, http_headers.get('Authorization'))
-        token_request['client_id'] = client_id
+        token_request['client_id']  = verify_client_authentication(self.clients, token_request, http_headers.get('Authorization'))
         return token_request
 
     def handle_userinfo_request(self, request=None, http_headers=None):

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -342,6 +342,8 @@ class Provider(object):
         authentication_request = self.authz_state.get_authorization_request_for_code(token_request['code'])
         
         if token_request['client_id'] != authentication_request['client_id']:
+            logger.info('Authorization code \'%s\' belonging to \'%s\' was used by \'%s\'',
+                        token_request['code'], authentication_request['client_id'], token_request['client_id'])
             raise InvalidAuthorizationCode('{} unknown'.format(token_request['code']))
         if token_request['redirect_uri'] != authentication_request['redirect_uri']:
             raise InvalidTokenRequest('Invalid redirect_uri: {} != {}'.format(token_request['redirect_uri'],

--- a/tests/pyop/test_client_authentication.py
+++ b/tests/pyop/test_client_authentication.py
@@ -41,21 +41,21 @@ class TestVerifyClientAuthentication(object):
     def test_authentication_method_defaults_to_client_secret_basic(self):
         del self.clients[TEST_CLIENT_ID]['token_endpoint_auth_method']
         authz_header = self.create_basic_auth()
-        assert verify_client_authentication(self.clients, self.token_request_args, authz_header)
+        assert verify_client_authentication(self.clients, self.token_request_args, authz_header) == TEST_CLIENT_ID
 
     def test_client_secret_post(self):
         self.clients[TEST_CLIENT_ID]['token_endpoint_auth_method'] = 'client_secret_post'
-        assert verify_client_authentication(self.clients, self.token_request_args)
+        assert verify_client_authentication(self.clients, self.token_request_args) == TEST_CLIENT_ID
 
     def test_client_secret_basic(self):
         self.clients[TEST_CLIENT_ID]['token_endpoint_auth_method'] = 'client_secret_basic'
         authz_header = self.create_basic_auth()
-        assert verify_client_authentication(self.clients, self.token_request_args, authz_header)
+        assert verify_client_authentication(self.clients, self.token_request_args, authz_header) == TEST_CLIENT_ID
 
     def test_unknown_client_id(self):
         self.token_request_args['client_id'] = 'unknown'
         with pytest.raises(InvalidClientAuthentication):
-            verify_client_authentication(self.clients, self.token_request_args)
+            verify_client_authentication(self.clients, self.token_request_args) == TEST_CLIENT_ID
 
     def test_wrong_client_secret(self):
         self.token_request_args['client_secret'] = 'foobar'
@@ -68,7 +68,7 @@ class TestVerifyClientAuthentication(object):
         self.clients[TEST_CLIENT_ID]['token_endpoint_auth_method'] = 'none'
         del self.clients[TEST_CLIENT_ID]['client_secret']
 
-        assert verify_client_authentication(self.clients, self.token_request_args, None)
+        assert verify_client_authentication(self.clients, self.token_request_args, None) == TEST_CLIENT_ID
 
     def test_invalid_authorization_scheme(self):
         authz_header = self.create_basic_auth()


### PR DESCRIPTION
When doing a code exchange make sure that the authorization code was issued to the authenticated client. Described in Section 3.1.3.2. of OpenID Connect Core 1.0.