### PR TITLE
Ignore unsupported scopes instead of failing

### DIFF
--- a/src/pyop/request_validator.py
+++ b/src/pyop/request_validator.py
@@ -96,9 +96,8 @@ def requested_scope_is_supported(provider, authentication_request):
     supported_scopes = set(provider.provider_configuration['scopes_supported'])
     requested_unsupported_scopes = requested_scopes - supported_scopes
     if requested_unsupported_scopes:
-        raise InvalidAuthenticationRequest('Request contains unsupported/unknown scopes: {}'
-                                           .format(', '.join(requested_unsupported_scopes)),
-                                           authentication_request, oauth_error='invalid_scope')
+        logger.warning('Request contains unsupported/unknown scopes: {}'
+                                           .format(', '.join(requested_unsupported_scopes)))
 
 
 def registration_request_verify(registration_request):

--- a/tests/pyop/test_provider.py
+++ b/tests/pyop/test_provider.py
@@ -122,13 +122,6 @@ class TestProviderParseAuthenticationRequest(object):
             self.provider.parse_authentication_request(urlencode(self.authn_request_args))
         assert isinstance(exc.value.__cause__, MissingRequiredValue)
 
-    def test_reject_request_with_unknown_scope(self):
-        self.authn_request_args['scope'] = 'openid unknown'
-
-        with pytest.raises(InvalidAuthenticationRequest) as exc:
-            self.provider.parse_authentication_request(urlencode(self.authn_request_args))
-        assert exc.value.oauth_error == 'invalid_scope'
-
     def test_custom_validation_hook_reject(self):
         class TestException(Exception):
             pass


### PR DESCRIPTION
 According to https://openid.net/specs/openid-connect-core-1_0.html
3.1.2.1 : " Scope values used that are not understood by an
implementation SHOULD be ignored"
Unsupported scopes are handled gracefully already in
https://github.com/OpenIDC/pyoidc/blob/master/src/oic/oic/__init__.py#L1773

This also fixes https://github.com/SUNET/SATOSA/issues/92